### PR TITLE
return partial dependency plot objects so they can be edited

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: brightbox
 Title: What the Package Does (one line, title case)
-Version: 0.0.0.9000
+Version: 0.0.0.9001
 Authors@R: c(
     person("Ronny", "Li", email = "ronny.li@breather.com", role = c("aut", "cre")),
     person("Benjamin", "Rollert", email = "ben.rollert@breather.com", role = c("aut")))

--- a/R/calculate_partial_dependency.R
+++ b/R/calculate_partial_dependency.R
@@ -54,8 +54,9 @@ calculate_partial_dependency <- function(feature_dt,
                          by = feature_col,
                          .SDcols = c(names(model_list),
                                      ensemble_colname)]
+  pd <- NA
   if (plot) {
-    print(ggplot2::ggplot(data = tidyr::gather(avg_pred,
+    pd <- ggplot2::ggplot(data = tidyr::gather(avg_pred,
                                                "model",
                                                "prediction",
                                                -1),
@@ -67,9 +68,11 @@ calculate_partial_dependency <- function(feature_dt,
             ggplot2::geom_line() +
             ggplot2::labs(title = paste("Partial dependency plot for",
                                         feature_col)) +
-            ggplot2::theme(plot.title = ggplot2::element_text(hjust = 0.5, face = "bold")))
+            ggplot2::theme(plot.title = ggplot2::element_text(hjust = 0.5, face = "bold"))
+    print(pd)
   }
-  return(avg_pred)
+  return(list(pdep = avg_pred,
+              plot = pd))
 }
 
 #' Calculate variable importance based on partial dependency for list of models
@@ -112,10 +115,13 @@ calculate_pd_vimp <- function(feature_dt,
   }
   # Calculate partial dependency range for each variable in feature_cols
   calculate_vimp_from_pd_list_ <- function(x) {
-    var <- colnames(x)[1]
-    vimp_range <- range(x[[vimp_colname]])
+    x_pdep <- x$pdep
+    x_plot <- x$plot
+    var <- colnames(x_pdep)[1]
+    vimp_range <- range(x_pdep[[vimp_colname]])
     return(data.table(var = var,
-                      vimp = vimp_range[2] - vimp_range[1]))
+                      vimp = vimp_range[2] - vimp_range[1],
+                      pdplot = list(x_plot)))
   }
   pd_vimp <- lapply(pd_list, calculate_vimp_from_pd_list_)
   # Return results as data.table

--- a/tests/testthat/test_calculate_partial_dependency_simple.R
+++ b/tests/testthat/test_calculate_partial_dependency_simple.R
@@ -18,7 +18,7 @@ test_that("calculate_partial_dependency works with numeric columns", {
                                          num_grid = 3,
                                          predict_fcn = fake_predict_fcn,
                                          ensemble_fcn = min,
-                                         plot = FALSE)
+                                         plot = FALSE)$pdep
   expected <- data.table(a = c(1, 3.5, 6),
                          m1 = c(-2.5, 0, 2.5),
                          m2 = c(0, 0, 0),
@@ -43,7 +43,7 @@ test_that("calculate_partial_dependency works with non-numeric columns", {
                                          num_grid = 3,
                                          predict_fcn = fake_predict_fcn,
                                          ensemble_fcn = min,
-                                         plot = FALSE)
+                                         plot = FALSE)$pdep
   expected <- data.table(c = LETTERS[1:6],
                          m1 = rep(0, 6),
                          m2 = rep(1, 6),


### PR DESCRIPTION
BREAKING CHANGE TO `calculate_partial_dependency`.

Function now returns a list containing a data.table and a plot object (optional) as opposed to a data.table.