### PR TITLE
add summary function argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: brightbox
 Title: Peek into any blackbox learner (including ensembles)
-Version: 0.0.0.9002
+Version: 0.0.0.9003
 Authors@R: c(
     person("Ronny", "Li", email = "ronny.li@breather.com", role = c("aut", "cre")),
     person("Benjamin", "Rollert", email = "ben.rollert@breather.com", role = c("aut")))

--- a/man/calculate_pd_vimp_normed.Rd
+++ b/man/calculate_pd_vimp_normed.Rd
@@ -5,20 +5,27 @@
 \title{Calculate normed variable importance based on partial dependency,
 taking into account model variability}
 \usage{
-calculate_pd_vimp_normed(pd, ensemble_colname = "ensemble", epsilon = 1e-07)
+calculate_pd_vimp_normed(pd, ensemble_colname = "ensemble", epsilon = 1e-07,
+  summary_fcn = median)
 }
 \arguments{
 \item{pd}{output from \code{\link{calculate_partial_dependency}}}
 
-\item{ensemble_colname}{name of ensemble column specified in \code{\link{calculate_partial_dependency}}.}
+\item{ensemble_colname}{name of ensemble column specified in
+\code{\link{calculate_partial_dependency}}.}
 
-\item{epsilon}{small value to add to the minimum standard deviation before dividing to prevent Inf return value.
-Defaults to 1e-07.}
+\item{epsilon}{small value to add to the minimum standard deviation before
+dividing to prevent Inf return value. Defaults to 1e-07.}
+
+\item{summary_fcn}{function to summarize vector of model standard deviations
+at each value cutpoint. Function must return a vector of length 1.
+Defaults to median.}
 }
 \description{
 Normed variable importance is calculated as the difference between the min and max,
-divided by the minimum standard deviation of the individual model predictions at any value cutpoint
-Most effective when training many models on different subsamples of training data.
+divided by the median (or other summary function) of the standard deviations
+of the individual model predictions at any value cutpoint. Most effective when
+training many models on different subsamples of training data.
 }
 \examples{
 \dontrun{
@@ -35,3 +42,4 @@ pd <- data.table(feature = rep("a", 9),
 calculate_pd_vimp_normed(pd, ensemble_colname = "ensemble")
 }
 }
+

--- a/tests/testthat/test_pd_vimp.R
+++ b/tests/testthat/test_pd_vimp.R
@@ -11,9 +11,17 @@ test_that("calculate_pd_vimp_normed returns expected value on toy data.table",{
                    prediction = c(c(-2.5, 0, 2.5),
                                   c(0, 0, 0),
                                   c(-2.5, -0.75, 0)))
-  vimp_normed <- calculate_pd_vimp_normed(pd, ensemble_colname = "ensemble")
+  # Assign value while suppressing warning
+  expect_warning(vimp_normed <- calculate_pd_vimp_normed(pd,
+                                                         ensemble_colname = "ensemble",
+                                                         summary_fcn = min))
   expect_equal(vimp_normed, 2.5e+07)
-  expect_warning(calculate_pd_vimp_normed(pd, ensemble_colname = "ensemble"))
+  expect_warning(vimp_normed_default <- calculate_pd_vimp_normed(pd,
+                                                                 ensemble_colname = "ensemble"))
+  expect_equal(round(vimp_normed_default, 6), 1.414213)
+  expect_error(expect_warning(calculate_pd_vimp_normed(pd,
+                                                       ensemble_colname = "ensemble",
+                                                       summary_fcn = function(x) x*2)))
   }
 )
 


### PR DESCRIPTION
`calculate_pd_vimp_normed` no longer assumes that user wants to use
`min` as summary function. Defaults to `median` now, with option to
specify user’s own function, so long as function returns a vector of
length 1.